### PR TITLE
Update tv.plug with Python.Version = 2

### DIFF
--- a/tv.plug
+++ b/tv.plug
@@ -4,3 +4,6 @@ Module = tv
 
 [Documentation]
 Description = So what's the status of this show ? 
+
+[Python]
+Version = 2


### PR DESCRIPTION
Most of this plugin works fine with Python3. However "next" and "season" are affected by the change in iterators

```
19:53:43 ERROR    root                      An error happened while processing a message ("@tv next Rick and Morty") from JID: Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/errbot/backends/base.py", line 994, in _execute_and_send
    reply = commands[cmd](mess, match) if match else commands[cmd](mess, args)
  File "/path/to/errbot/plugins/err-tv/tv.py", line 75, in tv_next
    for snb, season in show.iteritems():
AttributeError: 'Show' object has no attribute 'iteritems'
"
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/errbot/backends/base.py", line 994, in _execute_and_send
    reply = commands[cmd](mess, match) if match else commands[cmd](mess, args)
  File "/path/to/errbot/plugins/err-tv/tv.py", line 75, in tv_next
    for snb, season in show.iteritems():
AttributeError: 'Show' object has no attribute 'iteritems'
```

Additionally the "episode" method is broken in Python3.

```
19:54:15 ERROR    root                      An error happened while processing a message ("@tv episode Rick and Morty") from JID: Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/errbot/backends/base.py", line 994, in _execute_and_send
    reply = commands[cmd](mess, match) if match else commands[cmd](mess, args)
  File "/path/to/errbot/plugins/err-tv/tv.py", line 128, in tv_episode
    if  sxe.index('x') == -1:
ValueError: substring not found
"
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/errbot/backends/base.py", line 994, in _execute_and_send
    reply = commands[cmd](mess, match) if match else commands[cmd](mess, args)
  File "/path/to/errbot/plugins/err-tv/tv.py", line 128, in tv_episode
    if  sxe.index('x') == -1:
ValueError: substring not found
```
